### PR TITLE
Revert spring cloud version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     </parent>
 
     <properties>
-        <spring-cloud.version>Hoxton.SR1</spring-cloud.version>
+        <spring-cloud.version>Greenwich.SR1</spring-cloud.version>
         <nimbus-jose-jwt.version>8.4</nimbus-jose-jwt.version>
         <unirest-java.version>2.3.06</unirest-java.version>
         <logstash.version>6.3</logstash.version>


### PR DESCRIPTION
The spring cloud version needs to be compatible with the spring-boot
version